### PR TITLE
change homepage to link to speakers instead of livestream

### DIFF
--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -137,9 +137,11 @@ export function HomePage() {
             {/* Tickets CTA */}
               <div className="mt-12 sm:mt-16 flex flex-col items-center gap-6">
                 <motion.a
-                  href="https://youtube.com/live/ohZBlkOXFKA?feature=share"
-                  target="_blank"
-                  rel="noreferrer"
+                  href="/speakers"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    navigate("/speakers");
+                  }}
                   whileHover={{ y: -2, scale: 1.02 }}
                   whileTap={{ scale: 0.98 }}
                   className="
@@ -166,7 +168,7 @@ export function HomePage() {
                     "
                   />
                   <span className="relative flex items-center gap-2">
-                    🔴 Watch recording on YouTube
+                    🔴 Experience the talks →
                   </span>
                 </motion.a>
                 <motion.a


### PR DESCRIPTION
This pull request updates the call-to-action (CTA) on the home page to direct users to the internal speakers page instead of the livestream replay, since all talks are now live. The button text has also been changed to better reflect the new destination.

Navigation and CTA updates:

* Changed the CTA link in the `HomePage` component from an external YouTube recording to the internal `/speakers` page, using client-side navigation with `navigate`.
* Updated the CTA button text from "🔴 Watch recording on YouTube" to "🔴 Experience the talks →" to match the new link destination.