### PR TITLE
Add in-page video preview player to homepage carousel

### DIFF
--- a/src/components/Marquee.css
+++ b/src/components/Marquee.css
@@ -20,6 +20,15 @@
   flex: 0 0 auto;
   width: 320px;
   text-decoration: none;
+  /* Rendered as a <button>; strip the native button chrome. */
+  display: block;
+  padding: 0;
+  border: 0;
+  background: none;
+  text-align: left;
+  cursor: pointer;
+  color: inherit;
+  font: inherit;
 }
 
 .mq-thumb {

--- a/src/components/VideoMarquee.tsx
+++ b/src/components/VideoMarquee.tsx
@@ -1,47 +1,92 @@
+import { useEffect, useState } from "react";
 import { motion } from "motion/react";
 import { Play } from "lucide-react";
 import { allSpeakers, getYouTubeId } from "../data/sessions";
+import { VideoModal } from "./VideoModal";
 import "./Marquee.css";
 
+const STORAGE_KEY = "tedx-watched-talks";
+
+/** Names of watched talks, oldest first, persisted across visits. */
+function loadWatched(): string[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as string[]) : [];
+  } catch {
+    return [];
+  }
+}
+
 export function VideoMarquee() {
+  // Index into allSpeakers of the talk playing in the modal (null = closed).
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+  // Watch history drives the "least recently watched" queue order.
+  const [watched, setWatched] = useState<string[]>(loadWatched);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(watched));
+    } catch {
+      /* ignore storage failures (private mode, quota, etc.) */
+    }
+  }, [watched]);
+
+  // Open a talk and mark it as the most recently watched.
+  const openTalk = (index: number) => {
+    setActiveIndex(index);
+    const name = allSpeakers[index].name;
+    setWatched((prev) => [...prev.filter((n) => n !== name), name]);
+  };
+
   // Render the list twice so the track can loop seamlessly.
   const tiles = [...allSpeakers, ...allSpeakers];
 
   return (
-    <div className="mq-viewport">
-      <motion.div
-        className="mq-track"
-        animate={{ x: ["0%", "-50%"] }}
-        transition={{ duration: 165, ease: "linear", repeat: Infinity }}
-      >
-        {tiles.map((speaker, i) => {
-          const id = getYouTubeId(speaker.youtubeUrl);
-          return (
-            <a
-              key={`${speaker.name}-${i}`}
-              href={speaker.youtubeUrl}
-              target="_blank"
-              rel="noreferrer"
-              className="mq-tile group"
-              aria-label={`Watch ${speaker.name}'s talk: ${speaker.title}`}
-            >
-              <div className="mq-thumb">
-                <img
-                  src={id ? `https://img.youtube.com/vi/${id}/hqdefault.jpg` : speaker.image}
-                  alt={speaker.title}
-                  loading="lazy"
-                />
-                <div className="mq-thumb-overlay" />
-                <span className="mq-play" aria-hidden="true">
-                  <Play size={16} />
-                </span>
-              </div>
-              <p className="mq-caption">{speaker.title}</p>
-              <p className="mq-speaker">{speaker.name}</p>
-            </a>
-          );
-        })}
-      </motion.div>
-    </div>
+    <>
+      <div className="mq-viewport">
+        <motion.div
+          className="mq-track"
+          animate={{ x: ["0%", "-50%"] }}
+          transition={{ duration: 165, ease: "linear", repeat: Infinity }}
+        >
+          {tiles.map((speaker, i) => {
+            const id = getYouTubeId(speaker.youtubeUrl);
+            // The track is doubled, so map the tile back to its speaker index.
+            const speakerIndex = i % allSpeakers.length;
+            return (
+              <button
+                key={`${speaker.name}-${i}`}
+                type="button"
+                onClick={() => openTalk(speakerIndex)}
+                className="mq-tile group"
+                aria-label={`Watch ${speaker.name}'s talk: ${speaker.title}`}
+              >
+                <div className="mq-thumb">
+                  <img
+                    src={id ? `https://img.youtube.com/vi/${id}/hqdefault.jpg` : speaker.image}
+                    alt={speaker.title}
+                    loading="lazy"
+                  />
+                  <div className="mq-thumb-overlay" />
+                  <span className="mq-play" aria-hidden="true">
+                    <Play size={16} />
+                  </span>
+                </div>
+                <p className="mq-caption">{speaker.title}</p>
+                <p className="mq-speaker">{speaker.name}</p>
+              </button>
+            );
+          })}
+        </motion.div>
+      </div>
+
+      <VideoModal
+        speakers={allSpeakers}
+        activeIndex={activeIndex}
+        watched={watched}
+        onSelect={openTalk}
+        onClose={() => setActiveIndex(null)}
+      />
+    </>
   );
 }

--- a/src/components/VideoMarquee.tsx
+++ b/src/components/VideoMarquee.tsx
@@ -1,42 +1,13 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { motion } from "motion/react";
 import { Play } from "lucide-react";
 import { allSpeakers, getYouTubeId } from "../data/sessions";
 import { VideoModal } from "./VideoModal";
 import "./Marquee.css";
 
-const STORAGE_KEY = "tedx-watched-talks";
-
-/** Names of watched talks, oldest first, persisted across visits. */
-function loadWatched(): string[] {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    return raw ? (JSON.parse(raw) as string[]) : [];
-  } catch {
-    return [];
-  }
-}
-
 export function VideoMarquee() {
   // Index into allSpeakers of the talk playing in the modal (null = closed).
   const [activeIndex, setActiveIndex] = useState<number | null>(null);
-  // Watch history drives the "least recently watched" queue order.
-  const [watched, setWatched] = useState<string[]>(loadWatched);
-
-  useEffect(() => {
-    try {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(watched));
-    } catch {
-      /* ignore storage failures (private mode, quota, etc.) */
-    }
-  }, [watched]);
-
-  // Open a talk and mark it as the most recently watched.
-  const openTalk = (index: number) => {
-    setActiveIndex(index);
-    const name = allSpeakers[index].name;
-    setWatched((prev) => [...prev.filter((n) => n !== name), name]);
-  };
 
   // Render the list twice so the track can loop seamlessly.
   const tiles = [...allSpeakers, ...allSpeakers];
@@ -57,7 +28,7 @@ export function VideoMarquee() {
               <button
                 key={`${speaker.name}-${i}`}
                 type="button"
-                onClick={() => openTalk(speakerIndex)}
+                onClick={() => setActiveIndex(speakerIndex)}
                 className="mq-tile group"
                 aria-label={`Watch ${speaker.name}'s talk: ${speaker.title}`}
               >
@@ -83,8 +54,7 @@ export function VideoMarquee() {
       <VideoModal
         speakers={allSpeakers}
         activeIndex={activeIndex}
-        watched={watched}
-        onSelect={openTalk}
+        onSelect={setActiveIndex}
         onClose={() => setActiveIndex(null)}
       />
     </>

--- a/src/components/VideoMarquee.tsx
+++ b/src/components/VideoMarquee.tsx
@@ -5,9 +5,23 @@ import { allSpeakers, getYouTubeId } from "../data/sessions";
 import { VideoModal } from "./VideoModal";
 import "./Marquee.css";
 
+// The in-page player is a desktop-only feature. We gate it on device type
+// (touch-primary = phone/tablet), NOT window width, so a desktop user keeps the
+// full preview no matter how narrow they drag the window.
+const MOBILE_QUERY = "(hover: none) and (pointer: coarse)";
+
 export function VideoMarquee() {
   // Index into allSpeakers of the talk playing in the modal (null = closed).
   const [activeIndex, setActiveIndex] = useState<number | null>(null);
+
+  // Mobile/tablet opens the YouTube video in a new tab; desktop opens the modal.
+  const openTalk = (speaker: (typeof allSpeakers)[number], speakerIndex: number) => {
+    if (window.matchMedia(MOBILE_QUERY).matches) {
+      window.open(speaker.youtubeUrl, "_blank", "noopener,noreferrer");
+    } else {
+      setActiveIndex(speakerIndex);
+    }
+  };
 
   // Render the list twice so the track can loop seamlessly.
   const tiles = [...allSpeakers, ...allSpeakers];
@@ -28,7 +42,7 @@ export function VideoMarquee() {
               <button
                 key={`${speaker.name}-${i}`}
                 type="button"
-                onClick={() => setActiveIndex(speakerIndex)}
+                onClick={() => openTalk(speaker, speakerIndex)}
                 className="mq-tile group"
                 aria-label={`Watch ${speaker.name}'s talk: ${speaker.title}`}
               >

--- a/src/components/VideoModal.css
+++ b/src/components/VideoModal.css
@@ -99,6 +99,63 @@
   display: block;
 }
 
+/* ---------- Fallback when the embed can't load ---------- */
+.vm-player-fallback {
+  position: absolute;
+  inset: 0;
+  display: block;
+  text-decoration: none;
+}
+
+.vm-player-fallback img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.vm-player-fallback-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.85rem;
+  background: rgba(0, 0, 0, 0.55);
+  transition: background 0.18s ease;
+}
+
+.vm-player-fallback:hover .vm-player-fallback-overlay {
+  background: rgba(0, 0, 0, 0.42);
+}
+
+.vm-player-fallback-play {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 62px;
+  height: 62px;
+  border-radius: 999px;
+  color: #fff;
+  background: rgba(230, 43, 30, 0.95);
+  box-shadow: 0 10px 22px rgba(230, 43, 30, 0.35);
+  transition: transform 0.18s ease;
+}
+
+.vm-player-fallback:hover .vm-player-fallback-play {
+  transform: scale(1.06);
+}
+
+.vm-player-fallback-text {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #fff;
+}
+
 .vm-nav-btn {
   position: absolute;
   top: 50%;

--- a/src/components/VideoModal.css
+++ b/src/components/VideoModal.css
@@ -1,0 +1,344 @@
+/* VideoModal.css — in-page YouTube player for the HomePage video carousel.
+   Hand-written CSS (this project ships a pre-compiled Tailwind build, so new
+   utility classes are not available). Accent colors read the theme variables
+   so the modal works in both light and dark mode. */
+
+.vm-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 60; /* above the fixed nav (z-50) */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  background: rgba(0, 0, 0, 0.72);
+  -webkit-backdrop-filter: blur(6px);
+  backdrop-filter: blur(6px);
+}
+
+.vm-card {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  /* Definite height + a bounded row track so each column can scroll its own
+     overflow instead of the whole card clipping its content. */
+  grid-template-rows: minmax(0, 1fr);
+  gap: 1.25rem;
+  width: min(1120px, 100%);
+  height: min(92vh, 820px);
+  padding: 1.25rem;
+  border-radius: 1rem;
+  background: #14141b;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 18px 38px rgba(0, 0, 0, 0.34);
+  overflow: hidden;
+}
+
+.dark .vm-card {
+  background: #0f0f16;
+}
+
+/* ---------- Close button ---------- */
+.vm-close {
+  position: absolute;
+  top: 0.65rem;
+  right: 0.65rem;
+  z-index: 3;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border: 0;
+  border-radius: 999px;
+  cursor: pointer;
+  color: #fff;
+  background: rgba(0, 0, 0, 0.55);
+  transition: background 0.18s ease, transform 0.18s ease;
+}
+
+.vm-close:hover {
+  background: var(--tedx-red, #e62b1e);
+  transform: translateY(-1px);
+}
+
+/* ---------- Left column (player + speaker) ---------- */
+/* Scrollable areas keep their scroll but hide the visible scrollbar. */
+.vm-main,
+.vm-playlist-list {
+  scrollbar-width: none; /* Firefox */
+}
+
+.vm-main::-webkit-scrollbar,
+.vm-playlist-list::-webkit-scrollbar {
+  display: none; /* Chrome / Safari / Edge */
+}
+
+.vm-main {
+  min-width: 0;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+
+.vm-player {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  border-radius: 0.85rem;
+  overflow: hidden;
+  background: #000;
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.4);
+}
+
+.vm-player iframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  display: block;
+}
+
+.vm-nav-btn {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  border: 0;
+  border-radius: 999px;
+  cursor: pointer;
+  color: #fff;
+  background: rgba(0, 0, 0, 0.5);
+  opacity: 0.85;
+  transition: background 0.18s ease, opacity 0.18s ease;
+}
+
+.vm-nav-btn:hover {
+  opacity: 1;
+  background: rgba(230, 43, 30, 0.95);
+}
+
+.vm-nav-btn--prev {
+  left: 0.6rem;
+}
+
+.vm-nav-btn--next {
+  right: 0.6rem;
+}
+
+/* ---------- Speaker block ---------- */
+.vm-speaker {
+  display: flex;
+  gap: 1rem;
+  margin-top: 1.1rem;
+}
+
+.vm-headshot {
+  flex: 0 0 auto;
+  width: 84px;
+  height: 84px;
+  border-radius: 0.9rem;
+  object-fit: cover;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+}
+
+.vm-speaker-text {
+  min-width: 0;
+}
+
+.vm-talk-title {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 800;
+  line-height: 1.25;
+  letter-spacing: -0.01em;
+  color: #fff;
+}
+
+.vm-speaker-name {
+  margin: 0.3rem 0 0;
+  font-size: 0.92rem;
+  font-weight: 700;
+  color: var(--tedx-red, #e62b1e);
+}
+
+.vm-speaker-role {
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.vm-bio {
+  margin: 0.55rem 0 0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.86);
+}
+
+.vm-description {
+  margin: 0.45rem 0 0;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.vm-yt-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-top: 0.7rem;
+  font-size: 0.82rem;
+  font-weight: 700;
+  text-decoration: none;
+  color: #fff;
+  transition: color 0.18s ease;
+}
+
+.vm-yt-link:hover {
+  color: var(--tedx-red, #e62b1e);
+}
+
+/* ---------- Right column (playlist) ---------- */
+.vm-playlist {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.vm-playlist-heading {
+  margin: 0 0 0.6rem;
+  font-size: 0.7rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.vm-playlist-list {
+  list-style: none;
+  margin: 0;
+  padding: 0 0.35rem 0 0;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.vm-item {
+  display: flex;
+  gap: 0.65rem;
+  width: 100%;
+  padding: 0.4rem;
+  border: 0;
+  border-left: 3px solid transparent;
+  border-radius: 0.6rem;
+  cursor: pointer;
+  text-align: left;
+  background: transparent;
+  transition: background 0.18s ease, border-color 0.18s ease;
+}
+
+.vm-item:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.vm-item--active {
+  background: rgba(230, 43, 30, 0.16);
+  border-left-color: var(--tedx-red, #e62b1e);
+  box-shadow: inset 0 0 0 1px rgba(230, 43, 30, 0.35);
+}
+
+.vm-item--active:hover {
+  background: rgba(230, 43, 30, 0.2);
+}
+
+.vm-item-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.28rem;
+  margin-bottom: 0.15rem;
+  font-size: 0.62rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--tedx-red, #e62b1e);
+}
+
+.vm-item-thumb {
+  flex: 0 0 auto;
+  width: 96px;
+  aspect-ratio: 16 / 9;
+  border-radius: 0.4rem;
+  overflow: hidden;
+  background: rgba(0, 0, 0, 0.4);
+}
+
+.vm-item-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.vm-item-text {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.vm-item-title {
+  font-size: 0.8rem;
+  font-weight: 700;
+  line-height: 1.25;
+  color: rgba(255, 255, 255, 0.92);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.vm-item-name {
+  margin-top: 0.15rem;
+  font-size: 0.72rem;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+/* ---------- Mobile: single stacked column ---------- */
+@media (max-width: 860px) {
+  .vm-backdrop {
+    padding: 0.75rem;
+  }
+
+  .vm-card {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto auto;
+    /* Content-sized on mobile: the whole card scrolls, not each column. */
+    height: auto;
+    max-height: 94vh;
+    padding: 0.85rem;
+    gap: 0.85rem;
+    overflow-y: auto;
+  }
+
+  .vm-main {
+    min-height: auto;
+    overflow-y: visible;
+  }
+
+  .vm-playlist-list {
+    flex: 0 0 auto;
+    min-height: auto;
+    overflow-y: visible;
+  }
+
+  .vm-headshot {
+    width: 64px;
+    height: 64px;
+  }
+}

--- a/src/components/VideoModal.css
+++ b/src/components/VideoModal.css
@@ -366,8 +366,11 @@
   color: rgba(255, 255, 255, 0.55);
 }
 
-/* ---------- Mobile: single stacked column ---------- */
-@media (max-width: 860px) {
+/* ---------- Touch devices: single stacked column ----------
+   Gated on device type (touch-primary), NOT window width, so resizing a desktop
+   window never collapses the full two-column preview. Touch users are normally
+   redirected to YouTube before the modal opens; this stays as a safety net. */
+@media (hover: none) and (pointer: coarse) {
   .vm-backdrop {
     padding: 0.75rem;
   }

--- a/src/components/VideoModal.tsx
+++ b/src/components/VideoModal.tsx
@@ -1,0 +1,216 @@
+import { useEffect, useMemo, useRef } from "react";
+import { createPortal } from "react-dom";
+import { AnimatePresence, motion } from "motion/react";
+import { ChevronLeft, ChevronRight, ExternalLink, Play, X } from "lucide-react";
+import { getYouTubeId, type Speaker } from "../data/sessions";
+import "./VideoModal.css";
+
+type VideoModalProps = {
+  speakers: Speaker[];
+  /** Index of the talk currently playing, or null when the modal is closed. */
+  activeIndex: number | null;
+  /** Watched talk names, oldest first — drives the queue order. */
+  watched: string[];
+  onSelect: (index: number) => void;
+  onClose: () => void;
+};
+
+const thumb = (url: string) => {
+  const id = getYouTubeId(url);
+  return id ? `https://img.youtube.com/vi/${id}/hqdefault.jpg` : "";
+};
+
+export function VideoModal({ speakers, activeIndex, watched, onSelect, onClose }: VideoModalProps) {
+  const closeRef = useRef<HTMLButtonElement>(null);
+  const open = activeIndex !== null;
+  const count = speakers.length;
+
+  // Queue order: the talk now playing is pinned to the top; everything below is
+  // ordered least recently watched first (never-watched, then oldest → most
+  // recent). "Next" (order[1]) lands on the freshest unwatched talk.
+  const order = useMemo(() => {
+    const pos = new Map(watched.map((name, i) => [name, i]));
+    const rank = (i: number) => (pos.has(speakers[i].name) ? (pos.get(speakers[i].name) as number) : -1);
+    const rest = speakers
+      .map((_, i) => i)
+      .filter((i) => i !== activeIndex)
+      .sort((a, b) => rank(a) - rank(b) || a - b);
+    return activeIndex === null ? rest : [activeIndex, ...rest];
+  }, [speakers, watched, activeIndex]);
+
+  // Step through the queue in its displayed order (with wrap-around).
+  const step = (delta: number) => {
+    if (activeIndex === null) return;
+    const p = order.indexOf(activeIndex);
+    onSelect(order[(p + delta + count) % count]);
+  };
+
+  // Escape closes; arrow keys step through the queue.
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+      else if (e.key === "ArrowRight") step(1);
+      else if (e.key === "ArrowLeft") step(-1);
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  });
+
+  // Lock scrolling on the whole document (both html and body) while open, and
+  // pad for the removed scrollbar so the background doesn't shift.
+  useEffect(() => {
+    if (!open) return;
+    const { body, documentElement: html } = document;
+    const scrollBarWidth = window.innerWidth - html.clientWidth;
+    const prev = {
+      bodyOverflow: body.style.overflow,
+      htmlOverflow: html.style.overflow,
+      paddingRight: body.style.paddingRight,
+    };
+    body.style.overflow = "hidden";
+    html.style.overflow = "hidden";
+    if (scrollBarWidth > 0) body.style.paddingRight = `${scrollBarWidth}px`;
+    return () => {
+      body.style.overflow = prev.bodyOverflow;
+      html.style.overflow = prev.htmlOverflow;
+      body.style.paddingRight = prev.paddingRight;
+    };
+  }, [open]);
+
+  // Move focus to the close button when the modal opens.
+  useEffect(() => {
+    if (open) closeRef.current?.focus();
+  }, [open]);
+
+  return createPortal(
+    <AnimatePresence>
+      {open && activeIndex !== null && (
+        <motion.div
+          className="vm-backdrop"
+          onClick={onClose}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.2, ease: "easeOut" }}
+        >
+          <motion.div
+            className="vm-card"
+            role="dialog"
+            aria-modal="true"
+            aria-label={`${speakers[activeIndex].name}: ${speakers[activeIndex].title}`}
+            onClick={(e) => e.stopPropagation()}
+            initial={{ opacity: 0, scale: 0.96, y: 12 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.96, y: 12 }}
+            transition={{ duration: 0.22, ease: "easeOut" }}
+          >
+            <button
+              ref={closeRef}
+              type="button"
+              className="vm-close"
+              onClick={onClose}
+              aria-label="Close video"
+            >
+              <X size={20} />
+            </button>
+
+            {/* Left column: player + speaker block */}
+            <div className="vm-main">
+              <div className="vm-player">
+                <iframe
+                  key={activeIndex}
+                  src={`https://www.youtube.com/embed/${getYouTubeId(
+                    speakers[activeIndex].youtubeUrl,
+                  )}?autoplay=1&rel=0`}
+                  title={speakers[activeIndex].title}
+                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                  allowFullScreen
+                />
+                <button
+                  type="button"
+                  className="vm-nav-btn vm-nav-btn--prev"
+                  onClick={() => step(-1)}
+                  aria-label="Previous talk"
+                >
+                  <ChevronLeft size={26} />
+                </button>
+                <button
+                  type="button"
+                  className="vm-nav-btn vm-nav-btn--next"
+                  onClick={() => step(1)}
+                  aria-label="Next talk"
+                >
+                  <ChevronRight size={26} />
+                </button>
+              </div>
+
+              <div className="vm-speaker">
+                <img
+                  className="vm-headshot"
+                  src={speakers[activeIndex].image}
+                  alt={speakers[activeIndex].name}
+                  loading="lazy"
+                />
+                <div className="vm-speaker-text">
+                  <h3 className="vm-talk-title">{speakers[activeIndex].title}</h3>
+                  <p className="vm-speaker-name">
+                    {speakers[activeIndex].name}
+                    <span className="vm-speaker-role"> · {speakers[activeIndex].jobTitle}</span>
+                  </p>
+                  <p className="vm-bio">{speakers[activeIndex].bio}</p>
+                  <p className="vm-description">{speakers[activeIndex].description}</p>
+                  <a
+                    className="vm-yt-link"
+                    href={speakers[activeIndex].youtubeUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    Watch on YouTube
+                    <ExternalLink size={14} />
+                  </a>
+                </div>
+              </div>
+            </div>
+
+            {/* Right column: queue ordered least recently watched first. */}
+            <div className="vm-playlist" aria-label="Up next">
+              <p className="vm-playlist-heading">Up next</p>
+              <ul className="vm-playlist-list">
+                {order.map((index) => {
+                  const speaker = speakers[index];
+                  const isActive = index === activeIndex;
+                  return (
+                    <li key={speaker.name}>
+                      <button
+                        type="button"
+                        className={`vm-item${isActive ? " vm-item--active" : ""}`}
+                        onClick={() => onSelect(index)}
+                        aria-current={isActive ? "true" : undefined}
+                      >
+                        <span className="vm-item-thumb">
+                          <img src={thumb(speaker.youtubeUrl)} alt="" loading="lazy" />
+                        </span>
+                        <span className="vm-item-text">
+                          {isActive && (
+                            <span className="vm-item-badge">
+                              <Play size={9} fill="currentColor" />
+                              Now playing
+                            </span>
+                          )}
+                          <span className="vm-item-title">{speaker.title}</span>
+                          <span className="vm-item-name">{speaker.name}</span>
+                        </span>
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>,
+    document.body,
+  );
+}

--- a/src/components/VideoModal.tsx
+++ b/src/components/VideoModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { AnimatePresence, motion } from "motion/react";
 import { ChevronLeft, ChevronRight, ExternalLink, Play, X } from "lucide-react";
@@ -9,8 +9,6 @@ type VideoModalProps = {
   speakers: Speaker[];
   /** Index of the talk currently playing, or null when the modal is closed. */
   activeIndex: number | null;
-  /** Watched talk names, oldest first — drives the queue order. */
-  watched: string[];
   onSelect: (index: number) => void;
   onClose: () => void;
 };
@@ -20,30 +18,48 @@ const thumb = (url: string) => {
   return id ? `https://img.youtube.com/vi/${id}/hqdefault.jpg` : "";
 };
 
-export function VideoModal({ speakers, activeIndex, watched, onSelect, onClose }: VideoModalProps) {
+/** If the embed hasn't fired `load` within this window we assume it was
+    blocked (CSP, network, embedding disabled) and show the thumbnail fallback. */
+const EMBED_TIMEOUT_MS = 5000;
+
+export function VideoModal({ speakers, activeIndex, onSelect, onClose }: VideoModalProps) {
   const closeRef = useRef<HTMLButtonElement>(null);
+  const activeItemRef = useRef<HTMLLIElement>(null);
+  const failTimer = useRef<number | null>(null);
   const open = activeIndex !== null;
   const count = speakers.length;
 
-  // Queue order: the talk now playing is pinned to the top; everything below is
-  // ordered least recently watched first (never-watched, then oldest → most
-  // recent). "Next" (order[1]) lands on the freshest unwatched talk.
-  const order = useMemo(() => {
-    const pos = new Map(watched.map((name, i) => [name, i]));
-    const rank = (i: number) => (pos.has(speakers[i].name) ? (pos.get(speakers[i].name) as number) : -1);
-    const rest = speakers
-      .map((_, i) => i)
-      .filter((i) => i !== activeIndex)
-      .sort((a, b) => rank(a) - rank(b) || a - b);
-    return activeIndex === null ? rest : [activeIndex, ...rest];
-  }, [speakers, watched, activeIndex]);
+  // Whether the current video's embed failed to load (falls back to thumbnail).
+  const [embedFailed, setEmbedFailed] = useState(false);
 
-  // Step through the queue in its displayed order (with wrap-around).
+  // A successful iframe `load` cancels the pending timeout so the fallback can
+  // never appear over a working video.
+  const handleEmbedLoad = () => {
+    if (failTimer.current !== null) window.clearTimeout(failTimer.current);
+    setEmbedFailed(false);
+  };
+
+  // Step up/down the fixed playlist order (with wrap-around), like YouTube's
+  // Up next list — the "Now playing" highlight moves, the list stays put.
   const step = (delta: number) => {
     if (activeIndex === null) return;
-    const p = order.indexOf(activeIndex);
-    onSelect(order[(p + delta + count) % count]);
+    onSelect((activeIndex + delta + count) % count);
   };
+
+  // Reset the fallback state and arm a load-timeout each time the talk changes.
+  useEffect(() => {
+    if (activeIndex === null) return;
+    setEmbedFailed(false);
+    failTimer.current = window.setTimeout(() => setEmbedFailed(true), EMBED_TIMEOUT_MS);
+    return () => {
+      if (failTimer.current !== null) window.clearTimeout(failTimer.current);
+    };
+  }, [activeIndex]);
+
+  // Keep the highlighted row in view as navigation moves it down the list.
+  useEffect(() => {
+    if (open) activeItemRef.current?.scrollIntoView({ block: "nearest" });
+  }, [activeIndex, open]);
 
   // Escape closes; arrow keys step through the queue.
   useEffect(() => {
@@ -118,15 +134,37 @@ export function VideoModal({ speakers, activeIndex, watched, onSelect, onClose }
             {/* Left column: player + speaker block */}
             <div className="vm-main">
               <div className="vm-player">
-                <iframe
-                  key={activeIndex}
-                  src={`https://www.youtube.com/embed/${getYouTubeId(
-                    speakers[activeIndex].youtubeUrl,
-                  )}?autoplay=1&rel=0`}
-                  title={speakers[activeIndex].title}
-                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                  allowFullScreen
-                />
+                {embedFailed ? (
+                  <a
+                    className="vm-player-fallback"
+                    href={speakers[activeIndex].youtubeUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    <img src={thumb(speakers[activeIndex].youtubeUrl)} alt="" />
+                    <span className="vm-player-fallback-overlay">
+                      <span className="vm-player-fallback-play">
+                        <Play size={26} fill="currentColor" />
+                      </span>
+                      <span className="vm-player-fallback-text">
+                        Watch on YouTube
+                        <ExternalLink size={15} />
+                      </span>
+                    </span>
+                  </a>
+                ) : (
+                  <iframe
+                    key={activeIndex}
+                    src={`https://www.youtube.com/embed/${getYouTubeId(
+                      speakers[activeIndex].youtubeUrl,
+                    )}?autoplay=1&rel=0`}
+                    title={speakers[activeIndex].title}
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                    allowFullScreen
+                    onLoad={handleEmbedLoad}
+                    onError={() => setEmbedFailed(true)}
+                  />
+                )}
                 <button
                   type="button"
                   className="vm-nav-btn vm-nav-btn--prev"
@@ -173,15 +211,14 @@ export function VideoModal({ speakers, activeIndex, watched, onSelect, onClose }
               </div>
             </div>
 
-            {/* Right column: queue ordered least recently watched first. */}
+            {/* Right column: fixed playlist order; the highlight tracks playback. */}
             <div className="vm-playlist" aria-label="Up next">
               <p className="vm-playlist-heading">Up next</p>
               <ul className="vm-playlist-list">
-                {order.map((index) => {
-                  const speaker = speakers[index];
+                {speakers.map((speaker, index) => {
                   const isActive = index === activeIndex;
                   return (
-                    <li key={speaker.name}>
+                    <li key={speaker.name} ref={isActive ? activeItemRef : undefined}>
                       <button
                         type="button"
                         className={`vm-item${isActive ? " vm-item--active" : ""}`}

--- a/vercel.json
+++ b/vercel.json
@@ -20,7 +20,7 @@
         { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: img.youtube.com i.ytimg.com; frame-src https://news.tedxcongareevista.com; connect-src 'self'; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests"
+          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: img.youtube.com i.ytimg.com; frame-src https://news.tedxcongareevista.com https://www.youtube.com https://www.youtube-nocookie.com; connect-src 'self'; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests"
         }
       ]
     }


### PR DESCRIPTION
## Summary

Adds an in-page YouTube preview player to the homepage video carousel, replacing the old "open in a new tab" behavior for desktop visitors.

- **In-page modal player** — clicking a carousel tile opens a modal that autoplays the talk via a YouTube embed, with the speaker's headshot/bio below and a scrollable "Up next" playlist of every talk. Prev/next arrows and playlist rows move a "Now playing" highlight through the fixed list (YouTube-style); Escape/arrow keys and backdrop click work as expected.
- **CSP fix so embeds actually load on Vercel** — `frame-src` in `vercel.json` only allowed the news subdomain, which blocked YouTube iframes on deploy (worked locally only because the Vite dev server sends no CSP). Added `youtube.com`/`youtube-nocookie.com`.
- **Graceful embed fallback** — if an embed fails to load, the tile's thumbnail appears with a "Watch on YouTube" click-through; the failure timer is cancelled on successful load so it never covers a working video.
- **Device-gated, not width-gated** — the player is a desktop feature. Real touch devices (`(hover: none) and (pointer: coarse)`) are redirected straight to the YouTube video; desktop users keep the full two-column preview at any window width.

## Verification

- `npm run build` passes.
- Desktop: tile -> modal autoplays in-page; playlist/arrows switch video, bio, and highlight; Escape/backdrop close; background scroll locked; works in light and dark mode; narrow desktop window keeps the full preview.
- Mobile/touch: tile opens the YouTube video in a new tab; modal never appears.
- Speakers page "Watch Talk" links unchanged (still external YouTube).

> [!NOTE]
> The CSP change only takes effect on deploy — the previously-broken preview embeds should clear on the next Vercel build.